### PR TITLE
Added ability to tag an album

### DIFF
--- a/rdio-enhancer.js
+++ b/rdio-enhancer.js
@@ -407,11 +407,18 @@ function injectedJs() {
 
             // Save the tags when the user click on confirm
             this.$(".footer .blue").on("click", _.bind(function() {
-              var tags = this.$(".body .tags").val().trim().split(",");
-              tags = _.map(tags, function(tag) { return tag.trim(); });
+              var tags = _.map(this.$(".body .tags").val().trim().split(","), function(tag) { return tag.trim(); });
+
+              // Compare with previously set tags - might need to remove some
+              var previousTags = R.enhancer.getTagsForAlbum(that.model.get("albumKey"));
+
+              _.each(_.difference(previousTags, tags), function(removedTag) {
+                R.enhancer.removeTag(removedTag, that.model.get("albumKey"));
+              });
+
               R.enhancer.setTags(tags, that.model.get("albumKey"));
-              this.close();
               that.menuDirty = true;
+              this.close();
             }, this));
           };
           dialog.open()


### PR DESCRIPTION
Added the ability to tags an album and to filter a collection by a tag.

The tagging is done via the Collection page by displaying a "Tags" option in the action menu of an album. This allow to add, remove and edit tags.

The filtering is also available via the Collection page with the addition of a "Filter By Tag" textbox. The filtering can be a little slow at the moment as Rdio only partially load the albums of a collection. To be able to display all album associated with a tag, I need to fetch all the albums and then apply the filter. This will obviously be slower with larger collection.
