### PR TITLE
enable extension over https

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "all_frames": false,
       "js": [ "rdio-enhancer.js" ],
       "css": [ "rdio-enhancer.css" ],
-      "matches": [ "http://www.rdio.com/*" ],
+      "matches": [ "*://www.rdio.com/*" ],
       "run_at": "document_end"
    } ],
    "web_accessible_resources": ["options.html"],


### PR DESCRIPTION
Rdio now works over https, so I updated the manifest.
