### PR TITLE
Improved "Sort by Artist"

### DIFF
--- a/rdio-enhancer.js
+++ b/rdio-enhancer.js
@@ -783,16 +783,20 @@ function injectedJs() {
             if (artist_a_firstword == "the" || artist_a_firstword == "a") {
                 var newArtist = ""
                 for(i = 1; i < artist_a_split.length; i++) {
-                    newArtist += artist_a_split[i];
+                    newArtist += artist_a_split[i] + " ";
                 }
-                artist_a = newArtist;
+                if (newArtist != "") {
+                    artist_a = newArtist;
+                }
             }
             if (artist_b_firstword == "the" || artist_b_firstword == "a") {
                 var newArtist = ""
                 for(i = 1; i < artist_b_split.length; i++) {
-                    newArtist += artist_b_split[i];
+                    newArtist += artist_b_split[i] + " ";
                 }
-                artist_b = newArtist;
+                if (newArtist != "") {
+                    artist_b = newArtist;
+                }
             }
 
 			if (artist_a < artist_b) {


### PR DESCRIPTION
If an artist's name begins with 'The' or 'A', the sorting algorithm now ignores those words when sorting. This is how Rdio's Collection is sorted, as well as most other music apps. The current sorting makes bands like "The Beatles", "The White Stripes", "The Smiths", all appear under "T" which is incorrect.
