### PR TITLE
add editorconfig, remove options from tsconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,5 @@
 {
 	"compilerOptions": {
-		"out": "rdio-enhancer.js",
 		"sourceMap": true
-	},
-	"files": [
-		"rdio-enhancer.ts"
-	]
+	}
 }


### PR DESCRIPTION
* Added http://editorconfig.org/ for per-project editor defaults.
* I'd prefer to avoid `out`. Check out [`--out` is bad](https://github.com/TypeStrong/atom-typescript/blob/master/docs/out.md)